### PR TITLE
Undo the pytest way as batou currently does not support it.

### DIFF
--- a/src/batou_scm/tests/test_buildout.py
+++ b/src/batou_scm/tests/test_buildout.py
@@ -1,3 +1,4 @@
+from batou.conftest import root
 from batou import UpdateNeeded
 from batou.lib.file import Directory, File
 from batou_scm.buildout import Buildout, BuildoutWithVersionPins
@@ -6,8 +7,6 @@ import ConfigParser
 import StringIO
 import mock
 import pytest
-
-pytest_plugins = 'batou.conftest'
 
 
 @pytest.fixture
@@ -151,3 +150,6 @@ def test_buildout__BuildoutWithVersionPins__verify__2(
         has_outgoing_changesets.return_value = True
         with pytest.raises(UpdateNeeded):
             buildout.verify()
+
+
+root  # XXX satisfy pyflakes


### PR DESCRIPTION
This will be fixed in https://bitbucket.org/flyingcircus/batou/pull-requests/60/make-fixtures-reusable-by-calling/diff.